### PR TITLE
Couple of bug fixes:

### DIFF
--- a/public/src/card/card-analytics-dialog.html
+++ b/public/src/card/card-analytics-dialog.html
@@ -4,6 +4,10 @@
 <dom-module id="card-analytics-dialog">
   <template>
     <style is="custom-style" include="app-styles">
+      :host {
+        display: block;
+      }
+
       .container {
         text-align: center;
         font-size: 14px;

--- a/public/src/card/open-card-header.html
+++ b/public/src/card/open-card-header.html
@@ -228,8 +228,6 @@
       <!-- Tooltips -->
       <soso-tooltip for="likeRating" position="left" offset="10">[[ratingTip]]</soso-tooltip>
     </div>
-    <card-analytics-dialog id="analyticsDialog"></card-analytics-dialog>
-    <share-link-dialog id="shareDialog"></share-link-dialog>
   </template>
   <script>
     class OpenCardHeader extends Polymer.Element {
@@ -422,7 +420,7 @@
 
       _analytics() {
         this._import("card-analytics-dialog.html").then(() => {
-          this.$.analyticsDialog.show(this.data);
+          $dialogs.open("card-analytics-dialog", this.data);
         });
       }
 
@@ -490,7 +488,7 @@
       _onLink() {
         const cardUrl = this._shareUrl;
         this._import("../dialogs/share-link-dialog.html").then(() => {
-          return this.$.shareDialog.show(cardUrl);
+          $dialogs.open("share-link-dialog", cardUrl);
         });
       }
 

--- a/public/src/dialogs/share-link-dialog.html
+++ b/public/src/dialogs/share-link-dialog.html
@@ -3,6 +3,10 @@
 <dom-module id="share-link-dialog">
   <template>
     <style is="custom-style" include="app-styles">
+      :host {
+        display: block;
+      }
+
       #txt {
         width: 100%;
         box-sizing: border-box;
@@ -93,6 +97,10 @@
         });
       }
 
+      hide() {
+        return this.$.dlg.hide();
+      }
+
       _handleButton(event) {
         switch (event.detail.button.id) {
           case "copy":
@@ -102,7 +110,7 @@
             }
             break;
           default:
-            this.$.dlg.hide();
+            this.hide();
             this._resolve();
             this._resolve = null;
             break;

--- a/public/src/feed/feed-mixin.html
+++ b/public/src/feed/feed-mixin.html
@@ -74,9 +74,9 @@
           let fetchNewContent = true;
           let parsedRoute = this._parseRoute(route);
           if (!window.__dirtyFeed) {
-            if (this._parsedRoute && this._parsedRouteTimestamp) {
+            if (this._parsedRoute && this._lastFetchTimestamp) {
               if (parsedRoute.path === this._parsedRoute.path) {
-                let timeDiff = (new Date()).getTime() - this._parsedRouteTimestamp;
+                let timeDiff = (new Date()).getTime() - this._lastFetchTimestamp;
                 if (timeDiff < (5 * 60 * 1000)) {
                   fetchNewContent = false;
                 }
@@ -93,7 +93,7 @@
           window.__dirtyFeed = false;
 
           this._parsedRoute = parsedRoute;
-          this._parsedRouteTimestamp = (new Date()).getTime();
+          this._lastFetchTimestamp = (new Date()).getTime();
           this._moreAvailable = false;
           this._onMoreUpdated(this._moreAvailable);
           this._promotedCardIds = [];
@@ -203,6 +203,7 @@
 
       _fetchMore() {
         // called by super class when user requests more cards
+        this._lastFetchTimestamp = (new Date()).getTime();
         return $core.getFeed(this._parsedRoute.feedName, this._parsedRoute.count, this._parsedRoute.cardId, this._lastCardId, this._parsedRoute.channel, this._promotedCardIds).then((feed) => {
           const cards = feed.cards;
           this._lastCardId = null;

--- a/src/server-version.ts
+++ b/src/server-version.ts
@@ -1,1 +1,1 @@
-export const SERVER_VERSION = 247;
+export const SERVER_VERSION = 248;

--- a/src/server-version.ts
+++ b/src/server-version.ts
@@ -1,1 +1,1 @@
-export const SERVER_VERSION = 249;
+export const SERVER_VERSION = 250;


### PR DESCRIPTION
- When more is pressed, update last fetch time (used to refresh the feed after 5 mins)
- Update link share dialog and analytics dialog to be opened using the global dialog manager (other dialogs were already doing that). This ensures that they are always on top of whatever is on the page. (Especially if the container is inside an element that is using 3d transformation)