### PR TITLE
Bugs/kduffie

### DIFF
--- a/public/src/admin/admin-users-view.html
+++ b/public/src/admin/admin-users-view.html
@@ -87,8 +87,7 @@
       </div>
       <div class="table">
         <div class="headerRow">
-          <div class="headerCell">First</div>
-          <div class="headerCell">Last</div>
+          <div class="headerCell">Name</div>
           <div class="headerCell">Handle</div>
           <div class="headerCell">Address</div>
           <div class="headerCell">Email</div>
@@ -116,8 +115,7 @@
         </div>
         <template is="dom-repeat" items="[[users]]">
           <div class="row">
-            <div class="cell">[[item.firstName]]</div>
-            <div class="cell">[[item.lastName]]</div>
+            <div class="cell">[[item.name]]</div>
             <div class="cell clickable">
               <a href="[[item.channelUrl]]">[[item.handle]]</a>
             </div>
@@ -149,11 +147,12 @@
       </div>
       <h2>CSV</h2>
       <div class="csv">
-        <div class="csvRow">First, Last, Handle, Address, Email, Posts, Cards Opened, Cards Bought, Private, Revenue, Balance, Storage, IP Address,
-          Country, Region, City, Mailing List, Original Referer, Original Landing Page, Curation
+        <div class="csvRow">Name, First, Last, Handle, Address, Email, Posts, Cards Opened, Cards Bought, Private, Revenue, Balance, Storage,
+          IP Address, Country, Region, City, Mailing List, Original Referer, Original Landing Page, Curation
         </div>
         <template is="dom-repeat" items="[[users]]">
           <div class="csvRow">
+            <div class="csvCell">[[item.name]]</div>,
             <div class="csvCell">[[item.firstName]]</div>,
             <div class="csvCell">[[item.lastName]]</div>,
             <div class="csvCell">[[item.handle]]</div>,
@@ -216,6 +215,7 @@
             users.push({
               user: user,
               id: user.id,
+              name: user.identity ? user.identity.name : "",
               firstName: user.identity ? user.identity.firstName : "",
               lastName: user.identity ? user.identity.lastName : "",
               email: user.identity ? user.identity.emailAddress : "",

--- a/public/src/balance/withdraw-dialog.html
+++ b/public/src/balance/withdraw-dialog.html
@@ -218,7 +218,7 @@
         this.set('fees', 'US$' + fees.toFixed(2));
         const proceeds = this._floor2Digits(withdrawal - fees);
         this.set('proceeds', 'US$' + proceeds.toFixed(2));
-        if (!$core.isValidPaypalRecipient(this.$.email.value) || this.$.email.value !== this.$.emailConfirm.value) {
+        if (!$core.isValidPaypalRecipient(this.$.email.value.trim()) || this.$.email.value.trim() !== this.$.emailConfirm.value.trim()) {
           return;
         }
         this.$.btnSave.disabled = false;
@@ -233,7 +233,7 @@
         this.$.btnSave.disabled = true;
         this.$.email.disabled = true;
         this.$.withdrawalAmount.disabled = true;
-        $core.withdraw(Number(this.$.withdrawalAmount.value), this.$.email.value).then(() => {
+        $core.withdraw(Number(this.$.withdrawalAmount.value), this.$.email.value.trim()).then(() => {
           $router.goto("/balance");
         });
       }

--- a/src/feed-manager.ts
+++ b/src/feed-manager.ts
@@ -462,6 +462,9 @@ export class FeedManager implements Initializable, RestServer {
       if (feedCard.curation && feedCard.curation.block && feedCard.createdById !== user.id) {
         continue;
       }
+      if (feedCard.pricing.openPayment > 0) {
+        continue;  // exclude cards that pay you appearing in your feed just because you subscribe to that channel
+      }
       cardIds.push(feedCard.id);  // Never want to allow this card to show up again (based on score)
       if (!afterCardId) {  // Only include subscribed cards on first page of results
         const userCard = await db.findUserCardInfo(user.id, feedCard.id);

--- a/src/interfaces/db-records.ts
+++ b/src/interfaces/db-records.ts
@@ -393,6 +393,7 @@ export interface UserCardActionRecord {
   cardId: string;
   at: number;
   action: CardActionType;
+  fraudReason?: CardPaymentFraudReason;
   payment?: {
     amount: number;
     transactionId: string;
@@ -408,6 +409,7 @@ export interface UserCardActionRecord {
 }
 
 export type CardActionType = "impression" | "open" | "pay" | "close" | "like" | "reset-like" | "dislike" | "redeem-promotion" | "redeem-open-payment" | "redeem-click-payment" | "make-private" | "make-public" | "click";
+export type CardPaymentFraudReason = "author-fingerprint" | "prior-payor-fingerprint";
 
 export interface UserCardInfoRecord {
   userId: string;


### PR DESCRIPTION
This addresses several things together:

1)  admin-users page confusion over name (versus first/last)
2)  trim email addresses before validating in withdraw dialog (Darren's problem)
3)  detect fraudulent payment based on browser fingerprint only (rather than fingerprint plus IP address)
4)  when detecting fraud, add a reason into the corresponding "pay" user-card-action
5)  exclude ad cards from your feed (without earning potential) simply because you subscribe to the channel, but still allow those cards to be injected (with earning potential)